### PR TITLE
fixed build on mac

### DIFF
--- a/makefiles/setup.Makefile
+++ b/makefiles/setup.Makefile
@@ -44,12 +44,15 @@ compile-docker-mac: update-resources
 	# docker pull $(IMAGE)
 	mkdir -p /private/tmp/fake-$(USER)-home
 	docker run \
+		--rm \
 		-v $(gitdir):$(gitdir):delegated \
 		-v $(pwd1):$(pwd1):delegated \
 		-v /private/tmp/fake-$(USER)-home:/home/$(USER):delegated \
 		-e USER=$(USER) -e USERID=$(uid1) --user $(uid1) \
 		-e COLUMNS=$(cols)\
+		-ti \
 		"$(IMAGE)" \
+		/project/run-book-native.sh \
 		"$(BOOKNAME)" "$(SRC)" "$(RESOURCES)" \
 		"$(pwd1)"
 


### PR DESCRIPTION
The `--rm` is not necessary to make it work on Mac but it tells docker to delete the container once finished, which is useful if you don't want to end up with a thousand of stopped containers.