### PR TITLE
Fixing common bugs for Ubuntu

### DIFF
--- a/makefiles/setup.Makefile
+++ b/makefiles/setup.Makefile
@@ -33,9 +33,7 @@ compile-docker: update-resources
 		-v /tmp/fake-$(USER)-home:/home/$(USER) \
 		-e USER=$(USER) -e USERID=$(uid1) --user $(uid1) \
 		-e COLUMNS=$(cols)\
-		-ti \
 		"$(IMAGE)" \
-		/project/run-book-native.sh \
 		"$(BOOKNAME)" "$(SRC)" "$(RESOURCES)" \
 		"$(pwd1)"
 


### PR DESCRIPTION
Removed the run-book-native.sh line since compilation was failing due to this line.

Removed -ti line to ensure that IDEs like Atom may compile it (no TTY device).

@AndreaCensi 